### PR TITLE
add .env to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.env
 app/dist
 app/artifacts
 cache


### PR DESCRIPTION
avoid unfortunately lost of fund 

I recently clone this project and then upload to my github. Usually when I `npx hardhat` it automatically add `.env` to `.gitignore`, so I didn't aware much of it. That's why when I push the project to my github, I accidently uploaded `.env` file. Then all of my test net fund got scalped by bots. 